### PR TITLE
Add AGENTS.md for Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Python Flask HTTPS tile server that downloads USGS 3DEP LiDAR point cloud data from AWS S3, processes it into Digital Surface Models (DSM), and serves map tiles as PNGs. It uses PDAL for point cloud processing, which requires native C++ libraries.
+
+### Environment
+
+- **Conda environment**: `lidar` (installed via Miniforge at `~/miniforge3`)
+- **Activation**: `export PATH="$HOME/miniforge3/bin:$PATH" && eval "$(conda shell.bash hook)" && conda activate lidar`
+- PDAL *must* be installed via conda (not pip) because it requires native C++ libraries (`libpdal`).
+- `pyOpenSSL` is required for `generate_cert.py` but is not listed in `requirements.txt`.
+
+### Running the server
+
+1. Generate SSL certs if they don't exist: `python generate_cert.py` (creates `cert.pem` and `key.pem`)
+2. Start the server: `python lidar_dsm_tile_server.py` (HTTPS on port 5000)
+3. On first run without a cache, the server downloads ~50MB of GeoJSON boundary data from GitHub and caches it as `3dep_dataset_cache.pkl`.
+
+### Testing
+
+- There are no automated tests in this repository.
+- There is no linter configuration.
+- Manual testing: `curl -k https://localhost:5000/tiles/idw/18/74975/100281.png -o tile.png` (requests a DC-area LiDAR tile; takes a few seconds on first fetch due to AWS point cloud download).
+- Only zoom level 18 is supported; other zoom levels return HTTP 400.
+- Tiles for areas without LiDAR coverage return HTTP 404.
+
+### Key gotchas
+
+- The server requires `cert.pem` and `key.pem` in the working directory. These are gitignored and must be regenerated each session.
+- Tile requests that fetch new point cloud data from AWS can take 5-30+ seconds depending on point density and network speed.
+- The server creates `tiles/`, `dsms/`, and `pointclouds/` directories with method subdirectories (`min`, `max`, `mean`, `idw`) on startup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development environment instructions, including:

- Conda environment setup details (PDAL requires native C++ libraries via conda-forge)
- Server startup instructions (SSL cert generation + Flask HTTPS server)
- Manual testing guidance (curl commands for requesting tiles)
- Key gotchas (cert regeneration, AWS fetch latency, zoom-level restrictions)

## Environment Setup Verified

The full development environment was set up and verified end-to-end:

1. **Miniforge/conda** installed with `lidar` environment containing all dependencies (PDAL, Flask, geopandas, rioxarray, etc.)
2. **SSL certificates** generated via `generate_cert.py`
3. **Flask HTTPS tile server** started successfully on port 5000
4. **LiDAR tile request** completed successfully -- fetched point cloud data from AWS S3 for the Washington DC area, processed it into a DSM, and returned a 510x512 PNG tile

### Demo tile (DC area, zoom 18)

[LiDAR DSM tile of Washington DC area](https://cursor.com/agents/bc-c71cad02-04ea-47fc-9aa6-4d0a97cd1cf8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flidar_tile_dc.png)

### Server logs showing successful pipeline execution

[Server log output](https://cursor.com/agents/bc-c71cad02-04ea-47fc-9aa6-4d0a97cd1cf8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fserver_log.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c71cad02-04ea-47fc-9aa6-4d0a97cd1cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c71cad02-04ea-47fc-9aa6-4d0a97cd1cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

