### PR TITLE
Skip high-pass filter for stdev and count tiles (#47)

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -974,13 +974,13 @@ To cite this notebook:  Speed, C., Beckley, M., Crosby, C., & Nandigam, V. (2022
 """
 
 
-def process_dsm(dsm):
+def process_dsm(dsm, grid_method):
     # Handle NaN or masked values in DSM
     dsm_filled = np.nan_to_num(dsm, nan=np.nanmean(dsm))
-    # Apply a Gaussian filter to smooth the DSM
+    if grid_method in ('stdev', 'count'):
+        return dsm_filled
     sigma = 5  # Adjust sigma to control the degree of smoothing
     smoothed_dsm = gaussian_filter(dsm_filled, sigma=sigma)
-    # Subtract the smoothed DSM from the original DSM to apply a high-pass filter
     high_pass_dsm = dsm_filled - smoothed_dsm
     return high_pass_dsm
 
@@ -1034,7 +1034,7 @@ def serve_tile(grid_method, zoom, x, y):
         return "No data available for this tile", 404
 
     print(f"{zoom}/{x}/{y}: Processing image")
-    high_pass_dsm = process_dsm(dsm)
+    high_pass_dsm = process_dsm(dsm, grid_method)
     save_tile_png(high_pass_dsm, zoom, x, y, grid_method)
 
     return send_file(tile_filename, mimetype='image/png')
@@ -1049,7 +1049,7 @@ if __name__ == '__main__':
             print(f"Created directory: {dir}")
 
     # Create subdirectories for each grid method
-    grid_methods = ['min', 'max', 'mean', 'idw']
+    grid_methods = ['min', 'max', 'mean', 'idw', 'stdev', 'count']
     for method in grid_methods:
         for dir in ['tiles', 'dsms']:
             subdir = f'{dir}/{method}'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes https://github.com/endolith/usgs-lidar-tile-server/issues/47.

The tile pipeline applied the same Gaussian high-pass (elevation minus smoothed elevation) to every `grid_method`. For PDAL `writers.gdal` outputs **count** and **stdev**, that residual is not a meaningful visualization of the statistic and should use the gridded values directly (after NaN handling), consistent with how min/max/mean/idw benefit from edge emphasis on elevation.

## Changes

- `process_dsm(dsm, grid_method)` returns filled data only for `stdev` and `count`; other methods keep the existing high-pass.
- `serve_tile` passes `grid_method` into processing.
- Startup directory creation includes `stdev` and `count` under `tiles/` and `dsms/` so those URL paths work like the other methods.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-706c85e0-1f7b-4405-80eb-dc903bc15cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-706c85e0-1f7b-4405-80eb-dc903bc15cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

