### PR TITLE
Fix tile rendering skew from lidar outliers (#11)

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -297,24 +297,14 @@ def build_pdal_pipeline(extent_epsg3857, usgs_3dep_dataset_names,
     }
 
     if filterNoise == True:
-
-        # "Low noise" seems to include relevant points below vegetation?
-        # # Filter stage for class 7 (low noise points)
-        # filter_stage_class7 = {
-        #     "type": "filters.range",
-        #     "limits": "Classification![7:7]"
-        # }
-
-        # "High noise" means birds and other stuff high above terrain?
-        # Filter stage for class 18 (high noise points)
-        filter_stage_class18 = {
-            "type": "filters.range",
-            "limits": "Classification![18:18]"
+        # ASPRS LAS class 7 = low noise, 18 = high noise. filters.expression is
+        # streamable (unlike two-pass filters.outlier). Remaining misclassified
+        # spikes still need robust display scaling in save_tile_png (issue #11).
+        noise_filter_stage = {
+            "type": "filters.expression",
+            "expression": "Classification != 7 && Classification != 18",
         }
-
-        # Append both filter stages to the pipeline separately
-        # pointcloud_pipeline['pipeline'].append(filter_stage_class7)
-        pointcloud_pipeline['pipeline'].append(filter_stage_class18)
+        pointcloud_pipeline["pipeline"].append(noise_filter_stage)
 
     if reclassify == True:
 
@@ -1002,7 +992,27 @@ def save_tile_png(high_pass_dsm, zoom, x, y, grid_method, tile_size=512):
     canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(111)
 
-    ax.imshow(high_pass_dsm, cmap='gray', interpolation='nearest')
+    # Robust contrast: a handful of extreme DSM/high-pass values otherwise
+    # dominate matplotlib autoscale and the tile renders flat white (issue #11).
+    data = np.asarray(high_pass_dsm, dtype=float)
+    finite = data[np.isfinite(data)]
+    if finite.size > 0:
+        lo, hi = np.percentile(finite, [0.5, 99.5])
+        if lo >= hi:
+            lo = float(np.min(finite))
+            hi = float(np.max(finite))
+        if lo >= hi:
+            lo, hi = lo - 1.0, hi + 1.0
+    else:
+        lo, hi = -1.0, 1.0
+
+    ax.imshow(
+        high_pass_dsm,
+        cmap='gray',
+        interpolation='nearest',
+        vmin=lo,
+        vmax=hi,
+    )
     ax.axis('off')
     fig.subplots_adjust(left=0, right=1, top=1, bottom=0, wspace=0, hspace=0)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [issue #11](https://github.com/endolith/usgs-lidar-tile-server/issues/11): a few extreme Z values could skew DSM/high-pass range so slippy tiles rendered flat white.

## Changes

1. **Noise classes at ingest** — When `filterNoise` is on, the PDAL pipeline now uses a streamable `filters.expression` stage to drop ASPRS **Classification 7** (low noise) and **18** (high noise), not only class 18. Class 7 is the LAS “low point / noise” bucket that matches the reported very-low spikes; `filters.expression` stays compatible with `execute_streaming`.

2. **Robust tile contrast** — Before `imshow`, finite values are summarized with the **0.5 and 99.5 percentiles** to set `vmin`/`vmax`, so a handful of remaining outliers cannot dominate matplotlib’s autoscale. Degenerate cases (empty or constant data) fall back safely.

## Notes

- Cached `.laz` tiles built under the old pipeline still contain old classifications until re-fetched; new fetches get the stricter noise filter. The percentile scaling still improves PNGs from existing DSMs with rare bad pixels.
- Users who rely on class 7 points being present should turn off `filterNoise` (would require a code path exposing that flag to HTTP if desired later).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdb26bc7-a447-4e45-89ce-cb3e4798b86d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdb26bc7-a447-4e45-89ce-cb3e4798b86d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

