### PR TITLE
Fix missing Classification dimension on EPT tiles (issue #13)

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -296,6 +296,13 @@ def build_pdal_pipeline(extent_epsg3857, usgs_3dep_dataset_names,
         readers
     }
 
+    # EPT data may omit Classification; filters.range on it then errors (issue #13).
+    # Empty-source ferry creates the dimension when missing; existing values stay put.
+    pointcloud_pipeline["pipeline"].append({
+        "type": "filters.ferry",
+        "dimensions": "=>Classification",
+    })
+
     if filterNoise == True:
 
         # "Low noise" seems to include relevant points below vegetation?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes endolith/usgs-lidar-tile-server#13.

Some USGS EPT sources omit the LAS `Classification` dimension. The tile path uses `filters.range` with `Classification` (noise removal and DTM ground filter), which caused PDAL to raise `RuntimeError: filters.range: Invalid dimension name in 'limits' option: 'Classification'` for affected tiles (e.g. `/tiles/min/18/262137/182847.png`).

## Change

After all `readers.ept` stages, append `filters.ferry` with `dimensions: "=>Classification"`. Per PDAL behavior, this registers `Classification` when it is missing (default values) and does not overwrite existing values when the dimension is already present (empty source → `processOne` skips assignment).

## Notes

- `filters.ferry` is streamable, consistent with the existing streaming pipeline for `reclassify == False`.
- No dependency or PDAL version bump required beyond a PDAL that includes `filters.ferry` (standard).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4dba032-4adb-4d29-8b55-4a11d8f087e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4dba032-4adb-4d29-8b55-4a11d8f087e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

