### PR TITLE
Fix PDAL RuntimeError when EPT omits Classification dimension

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -237,6 +237,34 @@ def downsample_dem(dem):
         return dem
 
 
+# Entwine ept.json lists which dimensions exist for a dataset. Some USGS EPT
+# builds omit Classification; filters.range then raises "Invalid dimension name
+# 'Classification'" (see https://github.com/endolith/usgs-lidar-tile-server/issues/13).
+_EPT_SCHEMA_CLASSIFICATION_CACHE = {}
+
+
+def ept_schema_includes_classification(dataset_name):
+    """
+    Return True if the dataset's ept.json schema includes a Classification
+    dimension, so PDAL filters.range on Classification is valid.
+    """
+    if dataset_name in _EPT_SCHEMA_CLASSIFICATION_CACHE:
+        return _EPT_SCHEMA_CLASSIFICATION_CACHE[dataset_name]
+    url = (
+        f"https://s3-us-west-2.amazonaws.com/usgs-lidar-public/"
+        f"{dataset_name}/ept.json"
+    )
+    response = requests.get(url, timeout=60)
+    response.raise_for_status()
+    meta = response.json()
+    schema = meta.get("schema", [])
+    has_classification = any(
+        entry.get("name") == "Classification" for entry in schema
+    )
+    _EPT_SCHEMA_CLASSIFICATION_CACHE[dataset_name] = has_classification
+    return has_classification
+
+
 def build_pdal_pipeline(extent_epsg3857, usgs_3dep_dataset_names,
                         pc_resolution, filterNoise=False, reclassify=False,
                         savePointCloud=True, outCRS=3857,
@@ -670,6 +698,15 @@ def get_3dep_data(zoom, x, y, grid_method):
         number_pts_est.append(
             (int((AOI_EPSG3857.area/poly[2].area)*(poly[4]))))
 
+    filter_noise = all(
+        ept_schema_includes_classification(n) for n in usgs_3dep_datasets
+    )
+    if not filter_noise:
+        print(
+            f"{zoom}/{x}/{y}: At least one intersecting EPT dataset has no "
+            "Classification in its schema; skipping class-based noise filter."
+        )
+
     AOI_EPSG3857_wkt = AOI_EPSG3857.wkt
 
     # sum the estimates of the number of points from each 3DEP dataset within the AOI
@@ -747,7 +784,7 @@ def get_3dep_data(zoom, x, y, grid_method):
               f"as: {pc_filename}")
         pc_pipeline = build_pdal_pipeline(
             AOI_EPSG3857_wkt, usgs_3dep_datasets, pointcloud_resolution,
-            filterNoise=True, reclassify=reclassify, savePointCloud=True,
+            filterNoise=filter_noise, reclassify=reclassify, savePointCloud=True,
             outCRS=3857, pc_outName=pc_filename[:-4], pc_outType='laz')
 
     """
@@ -851,7 +888,7 @@ def get_3dep_data(zoom, x, y, grid_method):
     dsm_filename = f"dsms/{grid_method}/dsm_{zoom}_{x}_{y}.tif"
     dsm_pipeline = make_DEM_pipeline(
         AOI_EPSG3857_wkt, usgs_3dep_datasets, pointcloud_resolution,
-        dsm_resolution, filterNoise=True, reclassify=reclassify, savePointCloud=False,
+        dsm_resolution, filterNoise=filter_noise, reclassify=reclassify, savePointCloud=False,
         outCRS=3857, pc_outName=pc_filename[:-4], pc_outType='laz',
         demType='dsm', gridMethod=grid_method,
         dem_outName=dsm_filename[:-4], dem_outExt='tif', driver="GTiff")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes endolith/usgs-lidar-tile-server#13.

Some USGS 3DEP Entwine resources expose an `ept.json` schema that does not include `Classification`. The tile path always enabled `filterNoise`, which appends `filters.range` on `Classification` and triggers `RuntimeError: filters.range: Invalid dimension name in 'limits' option: 'Classification'`.

This change fetches each intersecting dataset's `ept.json` (with a small in-memory cache) and only enables `filterNoise` when every dataset's schema lists `Classification`. When any dataset omits it, classification-based noise filtering is skipped and a log line explains why.

**Trade-off:** For those tiles, class 18 (high noise) points are no longer stripped before DSM generation, which may slightly affect DSM quality compared to classified data.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f3bbe3-0ad1-4180-a59e-8c8a82e9de4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f3bbe3-0ad1-4180-a59e-8c8a82e9de4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

