### PR TITLE
Set MPLCONFIGDIR before matplotlib import (fixes #39)

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -71,6 +71,17 @@ import json
 import math
 import os
 import pickle
+import tempfile
+
+# Matplotlib reads MPLCONFIGDIR when first imported; if $HOME/.config/matplotlib
+# is not writable (common in serverless), it uses a random /tmp subdir and logs
+# a warning. A fixed writable directory keeps the font cache stable and speeds imports.
+if not os.environ.get("MPLCONFIGDIR"):
+    _mpl_config_dir = os.path.join(
+        tempfile.gettempdir(), "usgs-lidar-tile-server-matplotlib"
+    )
+    os.makedirs(_mpl_config_dir, exist_ok=True)
+    os.environ["MPLCONFIGDIR"] = _mpl_config_dir
 
 import geopandas as gpd
 import mercantile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[Issue #39](https://github.com/endolith/usgs-lidar-tile-server/issues/39): Matplotlib logs a warning and uses a random temporary cache directory when the default config path (for example under `$HOME/.config/matplotlib`) is not writable, which is common in serverless environments.

## Changes

- Import `tempfile` and, if `MPLCONFIGDIR` is not already set by the environment, set it to a stable writable directory under `tempfile.gettempdir()` (e.g. `.../usgs-lidar-tile-server-matplotlib`) and ensure it exists.
- This runs **before** any third-party imports so matplotlib’s first import sees the variable.

Users who need a specific location can still set `MPLCONFIGDIR` in the environment; the code does not override an existing value.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d32f89b-f256-4f7c-b466-004b0226ce97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d32f89b-f256-4f7c-b466-004b0226ce97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

