### PR TITLE
Fix fontconfig "No writable cache directories" (issue #40)

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -67,9 +67,23 @@ For ease-of-use, it is suggested to launch and execute these notebooks on <a hre
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/OpenTopography/OT_3DEP_Workflows/blob/main/notebooks/01_3DEP_Generate_DEM_User_AOI.ipynb)
 """
 
+import os
+
+# Matplotlib loads fontconfig; without a writable XDG cache (e.g. missing or
+# read-only $HOME), fontconfig logs "No writable cache directories". See
+# https://github.com/endolith/usgs-lidar-tile-server/issues/40
+_server_dir = os.path.dirname(os.path.abspath(__file__))
+_server_cache = os.path.join(_server_dir, ".cache")
+if not os.environ.get("XDG_CACHE_HOME"):
+    os.makedirs(_server_cache, exist_ok=True)
+    os.environ["XDG_CACHE_HOME"] = _server_cache
+if not os.environ.get("MPLCONFIGDIR"):
+    _mpl_config = os.path.join(os.environ["XDG_CACHE_HOME"], "matplotlib")
+    os.makedirs(_mpl_config, exist_ok=True)
+    os.environ["MPLCONFIGDIR"] = _mpl_config
+
 import json
 import math
-import os
 import pickle
 
 import geopandas as gpd


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[Issue #40](https://github.com/endolith/usgs-lidar-tile-server/issues/40): Matplotlib pulls in fontconfig, which needs a writable font cache. In environments where `$HOME` is missing or not writable (typical in some containers or minimal deployments), fontconfig logs **Fontconfig error: No writable cache directories**.

## Change

Before any matplotlib import, if `XDG_CACHE_HOME` is unset, set it to a `.cache` directory next to `lidar_dsm_tile_server.py` and create that directory. If `MPLCONFIGDIR` is unset, set it to `$XDG_CACHE_HOME/matplotlib` and create it.

Operators can still override both variables in the process environment (e.g. systemd `Environment=`).

## Notes

- This uses `XDG_CACHE_HOME` rather than `FONTCONFIG_FILE` because it matches common fontconfig behavior on Linux and avoids shipping a custom `fonts.conf`.
- `.cache` is already listed in `.gitignore`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a484fe0-2c9e-4387-850a-1e89351e5196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a484fe0-2c9e-4387-850a-1e89351e5196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

