### PR TITLE
Suppress PDAL DRACO plugin load warnings (fix #38)

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -71,6 +71,55 @@ import json
 import math
 import os
 import pickle
+import pathlib
+import sys
+import tempfile
+
+
+def _configure_pdal_driver_path_without_draco():
+    """Avoid PDAL repeatedly trying to load DRACO plugins when libdraco is absent.
+
+    Conda-forge PDAL often ships ``libpdal_plugin_*_draco.so``; if ``libdraco``
+    is not installed, ``PluginManager::loadAll`` logs an error for each broken
+    plugin. Setting ``PDAL_DRIVER_PATH`` replaces PDAL's default plugin search
+    paths (see PDAL ``PluginDirectory.cpp``), so we use a directory of symlinks
+    to every other ``libpdal_plugin_*`` in ``sys.prefix/lib`` and skip DRACO.
+    This project only uses EPT/LAS/GDAL stages, not DRACO. Respect a
+    user-provided ``PDAL_DRIVER_PATH`` and skip when no DRACO plugins exist.
+    """
+    if os.environ.get("PDAL_DRIVER_PATH"):
+        return
+    lib = pathlib.Path(sys.prefix) / "lib"
+    patterns = ("libpdal_plugin_*.so", "libpdal_plugin_*.dylib")
+    plugin_paths = []
+    for pattern in patterns:
+        plugin_paths.extend(lib.glob(pattern))
+    pdal_sub = lib / "pdal"
+    if pdal_sub.is_dir():
+        for pattern in patterns:
+            plugin_paths.extend(pdal_sub.glob(pattern))
+    if not plugin_paths:
+        return
+    draco = [p for p in plugin_paths if "draco" in p.name.lower()]
+    if not draco:
+        return
+    shim = pathlib.Path(
+        tempfile.mkdtemp(prefix="pdal_plugins_without_draco_"))
+    linked = 0
+    for path in plugin_paths:
+        if "draco" in path.name.lower():
+            continue
+        dest = shim / path.name
+        if dest.exists():
+            continue
+        dest.symlink_to(path.resolve())
+        linked += 1
+    if linked == 0:
+        return
+    os.environ["PDAL_DRIVER_PATH"] = str(shim)
+
+
+_configure_pdal_driver_path_without_draco()
 
 import geopandas as gpd
 import mercantile

--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -71,55 +71,6 @@ import json
 import math
 import os
 import pickle
-import pathlib
-import sys
-import tempfile
-
-
-def _configure_pdal_driver_path_without_draco():
-    """Avoid PDAL repeatedly trying to load DRACO plugins when libdraco is absent.
-
-    Conda-forge PDAL often ships ``libpdal_plugin_*_draco.so``; if ``libdraco``
-    is not installed, ``PluginManager::loadAll`` logs an error for each broken
-    plugin. Setting ``PDAL_DRIVER_PATH`` replaces PDAL's default plugin search
-    paths (see PDAL ``PluginDirectory.cpp``), so we use a directory of symlinks
-    to every other ``libpdal_plugin_*`` in ``sys.prefix/lib`` and skip DRACO.
-    This project only uses EPT/LAS/GDAL stages, not DRACO. Respect a
-    user-provided ``PDAL_DRIVER_PATH`` and skip when no DRACO plugins exist.
-    """
-    if os.environ.get("PDAL_DRIVER_PATH"):
-        return
-    lib = pathlib.Path(sys.prefix) / "lib"
-    patterns = ("libpdal_plugin_*.so", "libpdal_plugin_*.dylib")
-    plugin_paths = []
-    for pattern in patterns:
-        plugin_paths.extend(lib.glob(pattern))
-    pdal_sub = lib / "pdal"
-    if pdal_sub.is_dir():
-        for pattern in patterns:
-            plugin_paths.extend(pdal_sub.glob(pattern))
-    if not plugin_paths:
-        return
-    draco = [p for p in plugin_paths if "draco" in p.name.lower()]
-    if not draco:
-        return
-    shim = pathlib.Path(
-        tempfile.mkdtemp(prefix="pdal_plugins_without_draco_"))
-    linked = 0
-    for path in plugin_paths:
-        if "draco" in path.name.lower():
-            continue
-        dest = shim / path.name
-        if dest.exists():
-            continue
-        dest.symlink_to(path.resolve())
-        linked += 1
-    if linked == 0:
-        return
-    os.environ["PDAL_DRIVER_PATH"] = str(shim)
-
-
-_configure_pdal_driver_path_without_draco()
 
 import geopandas as gpd
 import mercantile

--- a/scripts/remove-pdal-draco-plugins.sh
+++ b/scripts/remove-pdal-draco-plugins.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Remove PDAL DRACO reader/writer plugins from a conda/mamba environment.
+#
+# Conda-forge PDAL often installs libpdal_plugin_*_draco.* even when libdraco
+# is not a dependency; PDAL still tries to load them and logs errors (see
+# GitHub issue #38). This tile server only needs EPT/LAS/GDAL-related stages.
+#
+# Deleting these shaves a little image size and avoids noisy startup logs.
+# Call from a Dockerfile after installing PDAL, for example:
+#   COPY scripts/remove-pdal-draco-plugins.sh /tmp/
+#   RUN chmod +x /tmp/remove-pdal-draco-plugins.sh \
+#       && CONDA_PREFIX=/opt/conda /tmp/remove-pdal-draco-plugins.sh
+#
+# Usage: CONDA_PREFIX=/path/to/env ./remove-pdal-draco-plugins.sh
+#    or: ./remove-pdal-draco-plugins.sh /path/to/env
+
+set -euo pipefail
+
+prefix="${1:-${CONDA_PREFIX:-}}"
+if [[ -z "${prefix}" ]]; then
+  echo "Set CONDA_PREFIX or pass the env root as the first argument." >&2
+  exit 1
+fi
+
+shopt -s nullglob
+removed=0
+for libdir in "${prefix}/lib" "${prefix}/lib/pdal"; do
+  [[ -d "${libdir}" ]] || continue
+  for f in "${libdir}"/libpdal_plugin_*draco*.so "${libdir}"/libpdal_plugin_*draco*.dylib; do
+    rm -f "${f}"
+    removed=$((removed + 1))
+  done
+done
+
+if [[ "${removed}" -eq 0 ]]; then
+  echo "No PDAL DRACO plugin libraries found under ${prefix}/lib (nothing to remove)." >&2
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves [issue #38](https://github.com/endolith/usgs-lidar-tile-server/issues/38): conda-installed PDAL often includes DRACO reader/writer plugins that depend on `libdraco.so`, which is not always installed. PDAL then logs errors when scanning plugins. This tile server only uses EPT/LAS/GDAL-related stages, so DRACO is unused.

## Approach (updated)

**Build-time removal** (better for Lambda/container size than a runtime workaround):

- Added `scripts/remove-pdal-draco-plugins.sh`, which deletes `libpdal_plugin_*draco*.so` / `.dylib` under `$CONDA_PREFIX/lib` and `$CONDA_PREFIX/lib/pdal`. Run it in the image Dockerfile after installing PDAL (see comments in the script for a `COPY` + `RUN` example).
- Removed the earlier Python `PDAL_DRIVER_PATH` symlink shim from `lidar_dsm_tile_server.py` so the app stays simple and the image stays smaller.

## Testing

- `bash -n scripts/remove-pdal-draco-plugins.sh`; manual test with a temp fake conda `lib` layout.
- `python3 -m py_compile lidar_dsm_tile_server.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef24e53f-b608-4063-a5ed-61f3855ea0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef24e53f-b608-4063-a5ed-61f3855ea0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

