### PR TITLE
Overview navigation tiles (z0–7) and LiDAR style crossfade to z14

### DIFF
--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -593,6 +593,40 @@ def create_bounding_box(sw_lat, sw_lon, ne_lat, ne_lon):
     return box(sw_lon, sw_lat, ne_lon, ne_lat)
 
 
+# Slippy-map tile size used for PNG output and for choosing DSM / EPT sampling.
+TILE_PNG_PX = 512
+# Zoom range for tiles. Lower zoom uses coarser EPT `resolution` (octree depth)
+# so each tile stays tractable; see GitHub issues #8 and #36.
+MIN_TILE_ZOOM = 14
+MAX_TILE_ZOOM = 18
+
+
+def tile_max_side_meters_3857(x, y, zoom):
+    """Longer Web Mercator edge of the tile, in meters (EPT / DSM use EPSG:3857)."""
+    b = mercantile.xy_bounds(x, y, zoom)
+    return max(b.right - b.left, b.top - b.bottom)
+
+
+def dsm_and_ept_resolution_m(x, y, zoom, tile_px=TILE_PNG_PX):
+    """
+    Ground sampling distance for the DSM grid and matching EPT octree spacing.
+
+    PDAL readers.ept `resolution` is a minimum voxel edge length in CRS units
+    (meters for 3857): larger values walk shallower in the octree and return
+    fewer points (issue #8). writers.gdal `resolution` sets DSM cell size; we
+    align it to ~one cell per output pixel so overview tiles are not gigapixel
+    rasters of full-density LiDAR.
+    """
+    span_m = tile_max_side_meters_3857(x, y, zoom)
+    dsm_m = span_m / float(tile_px)
+    # At the most detailed zoom, match prior behavior: finest octree (`0` = full).
+    if zoom >= MAX_TILE_ZOOM:
+        pc_m = 0.0
+    else:
+        pc_m = max(dsm_m * 0.65, 0.12)
+    return dsm_m, pc_m
+
+
 def tile_to_aoi(zoom, x, y):
     """
     Example usage:
@@ -614,6 +648,9 @@ def tile_to_aoi(zoom, x, y):
 
 def get_3dep_data(zoom, x, y, grid_method):
     reclassify = False
+
+    dsm_resolution_m, pointcloud_resolution = dsm_and_ept_resolution_m(
+        x, y, zoom)
 
     AOI_EPSG3857 = tile_to_aoi(zoom, x, y)
 
@@ -674,9 +711,19 @@ def get_3dep_data(zoom, x, y, grid_method):
 
     # sum the estimates of the number of points from each 3DEP dataset within the AOI
     num_pts_est = sum(number_pts_est)
-    pointcloud_resolution = 0.0  # This should get all points?
-    print(f'{zoom}/{x}/{y}: Using full resolution with approximately '
-          f'{int(math.ceil(num_pts_est/1e6)*1e6):,} points.')
+    # Rough point-count hint: at coarse EPT resolution, tile voxels ~ tile_area / pc^2.
+    tile_area_m2 = AOI_EPSG3857.area
+    if pointcloud_resolution > 0:
+        pts_cap_est = int(tile_area_m2 / max(pointcloud_resolution, 1e-6) ** 2)
+        print(
+            f'{zoom}/{x}/{y}: EPT resolution={pointcloud_resolution:.3f} m, '
+            f'DSM cell={dsm_resolution_m:.3f} m; naive voxel cap ~{pts_cap_est:,} pts '
+            f'(full-dataset AOI estimate was ~{int(math.ceil(num_pts_est/1e6)*1e6):,}).')
+    else:
+        print(
+            f'{zoom}/{x}/{y}: EPT resolution=0 (finest octree), '
+            f'DSM cell={dsm_resolution_m:.3f} m; full-dataset AOI estimate '
+            f'~{int(math.ceil(num_pts_est/1e6)*1e6):,} points.')
 
     """
     **Note**: Lidar point clouds can get *very* large, *very* fast, and the
@@ -847,11 +894,10 @@ def get_3dep_data(zoom, x, y, grid_method):
     # (Default is EPSG:3857 - Web Mercator Projection)
     # Change dem_outName to descriptive name; dem_outExt can be any extension supported by gdal.
 
-    dsm_resolution = 0.5  # TODO: Vary with pointcloud resolution?
     dsm_filename = f"dsms/{grid_method}/dsm_{zoom}_{x}_{y}.tif"
     dsm_pipeline = make_DEM_pipeline(
         AOI_EPSG3857_wkt, usgs_3dep_datasets, pointcloud_resolution,
-        dsm_resolution, filterNoise=True, reclassify=reclassify, savePointCloud=False,
+        dsm_resolution_m, filterNoise=True, reclassify=reclassify, savePointCloud=False,
         outCRS=3857, pc_outName=pc_filename[:-4], pc_outType='laz',
         demType='dsm', gridMethod=grid_method,
         dem_outName=dsm_filename[:-4], dem_outExt='tif', driver="GTiff")
@@ -918,7 +964,7 @@ def get_3dep_data(zoom, x, y, grid_method):
 
     # dsm = downsample_dem(dsm)
 
-    return dsm
+    return dsm, dsm_resolution_m
 
 
 """
@@ -974,13 +1020,21 @@ To cite this notebook:  Speed, C., Beckley, M., Crosby, C., & Nandigam, V. (2022
 """
 
 
-def process_dsm(dsm):
-    # Handle NaN or masked values in DSM
+def process_dsm(dsm, dsm_resolution_meters):
+    """
+    High-pass emphasis (DSM minus Gaussian low-pass) for subtle relief in iD.
+
+    `sigma` is in pixels (scipy.ndimage.gaussian_filter). When DSM cells are
+    large (zoomed out), a fixed pixel sigma removes only very short wavelengths
+    in ground meters, so the residual looks flat (issue #36). Scale sigma with
+    ground sample distance so the low-pass cutoff moves to a longer wavelength
+    at overview zooms.
+    """
     dsm_filled = np.nan_to_num(dsm, nan=np.nanmean(dsm))
-    # Apply a Gaussian filter to smooth the DSM
-    sigma = 5  # Adjust sigma to control the degree of smoothing
-    smoothed_dsm = gaussian_filter(dsm_filled, sigma=sigma)
-    # Subtract the smoothed DSM from the original DSM to apply a high-pass filter
+    ref_gsd_m = 0.35
+    sigma_px = 5.0 * (float(dsm_resolution_meters) / ref_gsd_m) ** 0.5
+    sigma_px = float(np.clip(sigma_px, 4.0, 26.0))
+    smoothed_dsm = gaussian_filter(dsm_filled, sigma=sigma_px)
     high_pass_dsm = dsm_filled - smoothed_dsm
     return high_pass_dsm
 
@@ -1018,8 +1072,11 @@ app = Flask(__name__)
 
 @app.route('/tiles/<string:grid_method>/<int:zoom>/<int:x>/<int:y>.png')
 def serve_tile(grid_method, zoom, x, y):
-    if zoom != 18:
-        return "Zoom level too low", 400
+    if zoom < MIN_TILE_ZOOM or zoom > MAX_TILE_ZOOM:
+        return (
+            f"Zoom level not supported (use {MIN_TILE_ZOOM}–{MAX_TILE_ZOOM})",
+            400,
+        )
 
     tile_filename = get_tile_filename(grid_method, zoom, x, y)
 
@@ -1027,14 +1084,17 @@ def serve_tile(grid_method, zoom, x, y):
         return send_file(tile_filename, mimetype='image/png')
 
     # Process tile directly
-    dsm = get_3dep_data(zoom, x, y, grid_method)
+    result = get_3dep_data(zoom, x, y, grid_method)
 
     # Check if we got any data
+    if result is None:
+        return "No data available for this tile", 404
+    dsm, dsm_resolution_m = result
     if dsm is None or dsm.size == 0:
         return "No data available for this tile", 404
 
     print(f"{zoom}/{x}/{y}: Processing image")
-    high_pass_dsm = process_dsm(dsm)
+    high_pass_dsm = process_dsm(dsm, dsm_resolution_m)
     save_tile_png(high_pass_dsm, zoom, x, y, grid_method)
 
     return send_file(tile_filename, mimetype='image/png')

--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -595,10 +595,25 @@ def create_bounding_box(sw_lat, sw_lon, ne_lat, ne_lon):
 
 # Slippy-map tile size used for PNG output and for choosing DSM / EPT sampling.
 TILE_PNG_PX = 512
-# Zoom range for tiles. Lower zoom uses coarser EPT `resolution` (octree depth)
-# so each tile stays tractable; see GitHub issues #8 and #36.
-MIN_TILE_ZOOM = 14
+# Full slippy-map zoom range served by this app.
+MIN_MAP_ZOOM = 0
 MAX_TILE_ZOOM = 18
+# z <= NAV_TILE_MAX_ZOOM: bearings-only tiles (no 3DEP); continental overview
+# cannot be built from EPT without an impractical number of readers per tile.
+NAV_TILE_MAX_ZOOM = 7
+# First zoom where we query 3DEP EPT (coarse octree + DSM pyramid still apply).
+LIDAR_TILE_MIN_ZOOM = 8
+# At and above this zoom, tiles are high-pass only (OSM cliff/building emphasis).
+# Between LIDAR_TILE_MIN_ZOOM and this level, we crossfade toward smoothed DSM.
+LIDAR_BLEND_FULL_HP_ZOOM = 14
+
+# Natural Earth 110m countries (public domain); cached locally after first fetch.
+_NE_110M_COUNTRIES = "natural_earth_110m_admin_0_countries.geojson"
+_NE_110M_URL = (
+    "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/"
+    "geojson/ne_110m_admin_0_countries.geojson"
+)
+_WORLD_OUTLINE_3857 = None
 
 
 def tile_max_side_meters_3857(x, y, zoom):
@@ -627,6 +642,77 @@ def dsm_and_ept_resolution_m(x, y, zoom, tile_px=TILE_PNG_PX):
     return dsm_m, pc_m
 
 
+def world_countries_3857():
+    """Natural Earth 110m land polygons in Web Mercator (lazy, disk-cached)."""
+    global _WORLD_OUTLINE_3857
+    if _WORLD_OUTLINE_3857 is not None:
+        return _WORLD_OUTLINE_3857
+    if not os.path.exists(_NE_110M_COUNTRIES):
+        print(f"Downloading Natural Earth 110m countries to {_NE_110M_COUNTRIES} …")
+        r = requests.get(_NE_110M_URL, timeout=120)
+        r.raise_for_status()
+        with open(_NE_110M_COUNTRIES, "wb") as f:
+            f.write(r.content)
+    gdf = gpd.read_file(_NE_110M_COUNTRIES)
+    _WORLD_OUTLINE_3857 = gdf.to_crs(epsg=3857)
+    return _WORLD_OUTLINE_3857
+
+
+def _graticule_step_deg(zoom):
+    if zoom <= 1:
+        return 45
+    if zoom <= 3:
+        return 15
+    if zoom <= 5:
+        return 10
+    if zoom <= 7:
+        return 5
+    return 2
+
+
+def _draw_graticule_3857(ax, west, south, east, north, zoom):
+    to3857 = pyproj.Transformer.from_crs(
+        pyproj.CRS("EPSG:4326"), pyproj.CRS("EPSG:3857"), always_xy=True
+    )
+    step = _graticule_step_deg(zoom)
+    lo = math.floor(west / step) * step
+    hi = math.ceil(east / step) * step
+    for lon in np.arange(lo, hi + step * 0.5, step):
+        xs, ys = to3857.transform([lon, lon], [south, north])
+        ax.plot(xs, ys, color="#2d2d3a", linewidth=0.45, solid_capstyle="round")
+    lo = math.floor(south / step) * step
+    hi = math.ceil(north / step) * step
+    for lat in np.arange(lo, hi + step * 0.5, step):
+        xs, ys = to3857.transform([west, east], [lat, lat])
+        ax.plot(xs, ys, color="#2d2d3a", linewidth=0.45, solid_capstyle="round")
+
+
+def render_navigation_tile_png(zoom, x, y, grid_method, tile_size=TILE_PNG_PX):
+    """
+    Low-zoom bearings layer: coastlines + graticule in Web Mercator (no LiDAR).
+    """
+    bbox_m = mercantile.xy_bounds(x, y, zoom)
+    ll = mercantile.bounds(x, y, zoom)
+    fig = Figure(figsize=(tile_size / 100, tile_size / 100), dpi=100)
+    canvas = FigureCanvasAgg(fig)
+    ax = fig.add_subplot(111)
+    ax.set_facecolor("#12121a")
+    ax.set_xlim(bbox_m.left, bbox_m.right)
+    ax.set_ylim(bbox_m.bottom, bbox_m.top)
+    ax.set_aspect("equal")
+
+    world = world_countries_3857()
+    world.boundary.plot(ax=ax, color="#4a5f78", linewidth=0.65, antialiased=True)
+    _draw_graticule_3857(ax, ll.west, ll.south, ll.east, ll.north, zoom)
+
+    ax.axis("off")
+    fig.subplots_adjust(left=0, right=1, top=1, bottom=0, wspace=0, hspace=0)
+    tile_filename = get_tile_filename(grid_method, zoom, x, y)
+    canvas.print_figure(tile_filename, dpi=100, pad_inches=0, bbox_inches="tight")
+    print(f"{zoom}/{x}/{y}: Navigation tile saved as {tile_filename}")
+    return tile_filename
+
+
 def tile_to_aoi(zoom, x, y):
     """
     Example usage:
@@ -648,6 +734,9 @@ def tile_to_aoi(zoom, x, y):
 
 def get_3dep_data(zoom, x, y, grid_method):
     reclassify = False
+
+    if zoom < LIDAR_TILE_MIN_ZOOM:
+        return None
 
     dsm_resolution_m, pointcloud_resolution = dsm_and_ept_resolution_m(
         x, y, zoom)
@@ -1020,7 +1109,7 @@ To cite this notebook:  Speed, C., Beckley, M., Crosby, C., & Nandigam, V. (2022
 """
 
 
-def process_dsm(dsm, dsm_resolution_meters):
+def process_dsm(dsm, dsm_resolution_meters, zoom):
     """
     High-pass emphasis (DSM minus Gaussian low-pass) for subtle relief in iD.
 
@@ -1029,6 +1118,10 @@ def process_dsm(dsm, dsm_resolution_meters):
     in ground meters, so the residual looks flat (issue #36). Scale sigma with
     ground sample distance so the low-pass cutoff moves to a longer wavelength
     at overview zooms.
+
+    Between LIDAR_TILE_MIN_ZOOM and LIDAR_BLEND_FULL_HP_ZOOM we crossfade from
+    normalized smoothed DSM (broad relief for bearings) toward pure high-pass
+    (edge mapping) as zoom increases.
     """
     dsm_filled = np.nan_to_num(dsm, nan=np.nanmean(dsm))
     ref_gsd_m = 0.35
@@ -1036,7 +1129,25 @@ def process_dsm(dsm, dsm_resolution_meters):
     sigma_px = float(np.clip(sigma_px, 4.0, 26.0))
     smoothed_dsm = gaussian_filter(dsm_filled, sigma=sigma_px)
     high_pass_dsm = dsm_filled - smoothed_dsm
-    return high_pass_dsm
+
+    if zoom >= LIDAR_BLEND_FULL_HP_ZOOM:
+        return high_pass_dsm
+
+    span = LIDAR_BLEND_FULL_HP_ZOOM - LIDAR_TILE_MIN_ZOOM
+    if span <= 0:
+        return high_pass_dsm
+    w_hp = (float(zoom) - LIDAR_TILE_MIN_ZOOM) / float(span)
+    w_hp = float(np.clip(w_hp, 0.0, 1.0))
+
+    def _norm01(a):
+        lo, hi = np.percentile(a, (2.0, 98.0))
+        if hi <= lo:
+            return np.zeros_like(a, dtype=np.float64)
+        return np.clip((a.astype(np.float64) - lo) / (hi - lo), 0.0, 1.0)
+
+    hi_n = _norm01(high_pass_dsm)
+    sm_n = _norm01(smoothed_dsm)
+    return (1.0 - w_hp) * sm_n + w_hp * hi_n
 
 
 def get_tile_filename(grid_method, zoom, x, y):
@@ -1048,15 +1159,15 @@ def get_tile_filename(grid_method, zoom, x, y):
     return f'tiles/{grid_method}/tile_{zoom}_{x}_{y}.png'
 
 
-def save_tile_png(high_pass_dsm, zoom, x, y, grid_method, tile_size=512):
-	# TODO: These are not always square for some reason, but iD seems to
-	# stretch them to square on its own
-    print(f"{zoom}/{x}/{y}: DSM data shape: {high_pass_dsm.shape}")
+def save_tile_png(raster, zoom, x, y, grid_method, tile_size=512):
+    # TODO: These are not always square for some reason, but iD seems to
+    # stretch them to square on its own
+    print(f"{zoom}/{x}/{y}: DSM data shape: {raster.shape}")
     fig = Figure(figsize=(tile_size/100, tile_size/100), dpi=100)
     canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(111)
 
-    ax.imshow(high_pass_dsm, cmap='gray', interpolation='nearest')
+    ax.imshow(raster, cmap='gray', interpolation='nearest')
     ax.axis('off')
     fig.subplots_adjust(left=0, right=1, top=1, bottom=0, wspace=0, hspace=0)
 
@@ -1072,9 +1183,9 @@ app = Flask(__name__)
 
 @app.route('/tiles/<string:grid_method>/<int:zoom>/<int:x>/<int:y>.png')
 def serve_tile(grid_method, zoom, x, y):
-    if zoom < MIN_TILE_ZOOM or zoom > MAX_TILE_ZOOM:
+    if zoom < MIN_MAP_ZOOM or zoom > MAX_TILE_ZOOM:
         return (
-            f"Zoom level not supported (use {MIN_TILE_ZOOM}–{MAX_TILE_ZOOM})",
+            f"Zoom level not supported (use {MIN_MAP_ZOOM}–{MAX_TILE_ZOOM})",
             400,
         )
 
@@ -1083,10 +1194,12 @@ def serve_tile(grid_method, zoom, x, y):
     if os.path.exists(tile_filename):
         return send_file(tile_filename, mimetype='image/png')
 
-    # Process tile directly
+    if zoom <= NAV_TILE_MAX_ZOOM:
+        render_navigation_tile_png(zoom, x, y, grid_method)
+        return send_file(tile_filename, mimetype='image/png')
+
     result = get_3dep_data(zoom, x, y, grid_method)
 
-    # Check if we got any data
     if result is None:
         return "No data available for this tile", 404
     dsm, dsm_resolution_m = result
@@ -1094,8 +1207,8 @@ def serve_tile(grid_method, zoom, x, y):
         return "No data available for this tile", 404
 
     print(f"{zoom}/{x}/{y}: Processing image")
-    high_pass_dsm = process_dsm(dsm, dsm_resolution_m)
-    save_tile_png(high_pass_dsm, zoom, x, y, grid_method)
+    display_raster = process_dsm(dsm, dsm_resolution_m, zoom)
+    save_tile_png(display_raster, zoom, x, y, grid_method)
 
     return send_file(tile_filename, mimetype='image/png')
 

--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -71,7 +71,6 @@ import json
 import math
 import os
 import pickle
-import re
 
 import geopandas as gpd
 import mercantile
@@ -81,9 +80,6 @@ import pyproj
 import requests
 import rioxarray as rio
 from flask import Flask, send_file
-from matplotlib import cm as mpl_cm
-from matplotlib import colors as mpl_colors
-from matplotlib.cm import ScalarMappable
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 from rasterio.enums import Resampling
@@ -602,8 +598,8 @@ TILE_PNG_PX = 512
 # Full slippy-map zoom range served by this app.
 MIN_MAP_ZOOM = 0
 MAX_TILE_ZOOM = 18
-# z <= NAV_TILE_MAX_ZOOM: bearings-only tiles (no 3DEP); continental overview
-# cannot be built from EPT without an impractical number of readers per tile.
+# z <= NAV_TILE_MAX_ZOOM: transparent survey-footprint tiles only (no LiDAR).
+# The map client supplies geography; only 3DEP coverage is drawn here.
 NAV_TILE_MAX_ZOOM = 7
 # First zoom where we query 3DEP EPT (coarse octree + DSM pyramid still apply).
 LIDAR_TILE_MIN_ZOOM = 8
@@ -611,30 +607,75 @@ LIDAR_TILE_MIN_ZOOM = 8
 # Between LIDAR_TILE_MIN_ZOOM and this level, we crossfade toward smoothed DSM.
 LIDAR_BLEND_FULL_HP_ZOOM = 14
 
-# Natural Earth 110m countries (public domain); cached locally after first fetch.
-_NE_110M_COUNTRIES = "natural_earth_110m_admin_0_countries.geojson"
-_NE_110M_URL = (
-    "https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/"
-    "geojson/ne_110m_admin_0_countries.geojson"
-)
-_WORLD_OUTLINE_3857 = None
-_SURVEYS_META_GDF_3857 = None
-
-_YEAR_IN_NAME = re.compile(r"\b((?:19|20)\d{2})\b")
+_SURVEYS_FOOTPRINTS_GDF_3857 = None
 
 
-def _parse_acquisition_year_from_survey_name(name):
+def surveys_footprints_gdf_3857():
+    """3DEP public EPT footprints (resources.geojson) in Web Mercator."""
+    global _SURVEYS_FOOTPRINTS_GDF_3857
+    if _SURVEYS_FOOTPRINTS_GDF_3857 is not None:
+        return _SURVEYS_FOOTPRINTS_GDF_3857
+    _SURVEYS_FOOTPRINTS_GDF_3857 = gpd.GeoDataFrame(
+        geometry=geometries_EPSG3857.values,
+        crs="EPSG:3857",
+    )
+    return _SURVEYS_FOOTPRINTS_GDF_3857
+
+
+def _surveys_intersecting_tile_3857(tile_poly):
+    gdf = surveys_footprints_gdf_3857()
+    cand = list(gdf.sindex.intersection(tile_poly.bounds))
+    if not cand:
+        return gdf.iloc[[]].copy()
+    sub = gdf.iloc[cand]
+    return sub[sub.intersects(tile_poly)].copy()
+
+
+def render_navigation_tile_png(zoom, x, y, grid_method, tile_size=TILE_PNG_PX):
     """
-    resources.geojson has no explicit collection-year field; USGS dataset ids
-    usually embed a four-digit year (e.g. AK_BrooksCamp_2012). Last match wins
-    when several years appear (e.g. project phases).
+    Low-zoom tiles (no LiDAR): 3DEP EPT survey footprint polygons only.
+
+    Transparent PNG so the client basemap shows through; no legends or text.
     """
-    if name is None:
-        return None
-    matches = _YEAR_IN_NAME.findall(str(name))
-    if not matches:
-        return None
-    return int(matches[-1])
+    bbox_m = mercantile.xy_bounds(x, y, zoom)
+    tile_poly = box(bbox_m.left, bbox_m.bottom, bbox_m.right, bbox_m.top)
+
+    fig = Figure(figsize=(tile_size / 100, tile_size / 100), dpi=100)
+    fig.patch.set_alpha(0.0)
+    canvas = FigureCanvasAgg(fig)
+    ax = fig.add_subplot(111)
+    ax.set_facecolor((0, 0, 0, 0))
+    ax.patch.set_alpha(0.0)
+    ax.set_xlim(bbox_m.left, bbox_m.right)
+    ax.set_ylim(bbox_m.bottom, bbox_m.top)
+    ax.set_aspect("equal")
+
+    surveys = _surveys_intersecting_tile_3857(tile_poly)
+    if len(surveys) > 0:
+        surveys = surveys.assign(_area=surveys.geometry.area).sort_values(
+            "_area", ascending=True
+        )
+        surveys.plot(
+            ax=ax,
+            facecolor=(0.35, 0.65, 0.42, 0.22),
+            edgecolor=(0.15, 0.45, 0.22, 0.75),
+            linewidth=0.65,
+            legend=False,
+        )
+
+    ax.axis("off")
+    fig.subplots_adjust(left=0, right=1, top=1, bottom=0, wspace=0, hspace=0)
+
+    tile_filename = get_tile_filename(grid_method, zoom, x, y)
+    canvas.print_figure(
+        tile_filename,
+        dpi=100,
+        pad_inches=0,
+        bbox_inches="tight",
+        transparent=True,
+    )
+    print(f"{zoom}/{x}/{y}: Navigation tile saved as {tile_filename}")
+    return tile_filename
 
 
 def tile_max_side_meters_3857(x, y, zoom):
@@ -661,198 +702,6 @@ def dsm_and_ept_resolution_m(x, y, zoom, tile_px=TILE_PNG_PX):
     else:
         pc_m = max(dsm_m * 0.65, 0.12)
     return dsm_m, pc_m
-
-
-def world_countries_3857():
-    """Natural Earth 110m land polygons in Web Mercator (lazy, disk-cached)."""
-    global _WORLD_OUTLINE_3857
-    if _WORLD_OUTLINE_3857 is not None:
-        return _WORLD_OUTLINE_3857
-    if not os.path.exists(_NE_110M_COUNTRIES):
-        print(f"Downloading Natural Earth 110m countries to {_NE_110M_COUNTRIES} …")
-        r = requests.get(_NE_110M_URL, timeout=120)
-        r.raise_for_status()
-        with open(_NE_110M_COUNTRIES, "wb") as f:
-            f.write(r.content)
-    gdf = gpd.read_file(_NE_110M_COUNTRIES)
-    _WORLD_OUTLINE_3857 = gdf.to_crs(epsg=3857)
-    return _WORLD_OUTLINE_3857
-
-
-def surveys_metadata_gdf_3857():
-    """
-    3DEP public EPT footprints (hobuinc/usgs-lidar resources.geojson) in Web Mercator.
-
-    Only name / count / geometry are authoritative; acquisition year is inferred
-    from the dataset id string when present (same idea as USGS 'by collection
-    year' overview maps, but approximate).
-    """
-    global _SURVEYS_META_GDF_3857
-    if _SURVEYS_META_GDF_3857 is not None:
-        return _SURVEYS_META_GDF_3857
-    n = len(geometries_EPSG3857)
-    years = []
-    for i in range(n):
-        years.append(_parse_acquisition_year_from_survey_name(names.iloc[i]))
-    year_col = np.array(
-        [float(y) if y is not None else np.nan for y in years], dtype=np.float64
-    )
-    counts = np.asarray(num_points, dtype=np.float64)
-    counts = np.where(np.isfinite(counts) & (counts > 0), counts, np.nan)
-    _SURVEYS_META_GDF_3857 = gpd.GeoDataFrame(
-        {
-            "name": names.values,
-            "count": counts,
-            "year": year_col,
-            "geometry": geometries_EPSG3857.values,
-        },
-        crs="EPSG:3857",
-    )
-    return _SURVEYS_META_GDF_3857
-
-
-def _surveys_intersecting_tile_3857(tile_poly):
-    gdf = surveys_metadata_gdf_3857()
-    cand = list(gdf.sindex.intersection(tile_poly.bounds))
-    if not cand:
-        return gdf.iloc[[]].copy()
-    sub = gdf.iloc[cand]
-    return sub[sub.intersects(tile_poly)].copy()
-
-
-def _graticule_step_deg(zoom):
-    if zoom <= 1:
-        return 45
-    if zoom <= 3:
-        return 15
-    if zoom <= 5:
-        return 10
-    if zoom <= 7:
-        return 5
-    return 2
-
-
-def _draw_graticule_3857(ax, west, south, east, north, zoom):
-    to3857 = pyproj.Transformer.from_crs(
-        pyproj.CRS("EPSG:4326"), pyproj.CRS("EPSG:3857"), always_xy=True
-    )
-    step = _graticule_step_deg(zoom)
-    lo = math.floor(west / step) * step
-    hi = math.ceil(east / step) * step
-    for lon in np.arange(lo, hi + step * 0.5, step):
-        xs, ys = to3857.transform([lon, lon], [south, north])
-        ax.plot(xs, ys, color="#2d2d3a", linewidth=0.45, solid_capstyle="round")
-    lo = math.floor(south / step) * step
-    hi = math.ceil(north / step) * step
-    for lat in np.arange(lo, hi + step * 0.5, step):
-        xs, ys = to3857.transform([west, east], [lat, lat])
-        ax.plot(xs, ys, color="#2d2d3a", linewidth=0.45, solid_capstyle="round")
-
-
-def render_navigation_tile_png(zoom, x, y, grid_method, tile_size=TILE_PNG_PX):
-    """
-    Low-zoom bearings layer (no LiDAR): Natural Earth coastlines, graticule, and
-    USGS public EPT survey footprints from resources.geojson.
-
-    Survey polygons use fill color by acquisition year parsed from the dataset id
-    (resources have no separate year field). Edge weight scales slightly with
-    log10(point count) so larger acquisitions read heavier—similar in spirit to
-    overview maps that combine coverage with vintage / quality cues.
-    """
-    bbox_m = mercantile.xy_bounds(x, y, zoom)
-    ll = mercantile.bounds(x, y, zoom)
-    tile_poly = box(bbox_m.left, bbox_m.bottom, bbox_m.right, bbox_m.top)
-
-    fig = Figure(figsize=(tile_size / 100, tile_size / 100), dpi=100)
-    canvas = FigureCanvasAgg(fig)
-    ax = fig.add_subplot(111)
-    ax.set_facecolor("#12121a")
-    ax.set_xlim(bbox_m.left, bbox_m.right)
-    ax.set_ylim(bbox_m.bottom, bbox_m.top)
-    ax.set_aspect("equal")
-
-    world = world_countries_3857()
-    world.boundary.plot(ax=ax, color="#4a5f78", linewidth=0.65, antialiased=True)
-
-    surveys = _surveys_intersecting_tile_3857(tile_poly)
-    year_norm = mpl_colors.Normalize(vmin=1998.0, vmax=2026.0)
-    try:
-        year_cmap = mpl_cm.colormaps["YlGnBu"]
-    except AttributeError:
-        year_cmap = mpl_cm.get_cmap("YlGnBu")
-    sm = ScalarMappable(norm=year_norm, cmap=year_cmap)
-    sm.set_array([])
-
-    if len(surveys) > 0:
-        surveys = surveys.assign(_area=surveys.geometry.area).sort_values(
-            "_area", ascending=True
-        )
-        logc = np.log10(
-            np.maximum(surveys["count"].to_numpy(dtype=np.float64), 1.0)
-        )
-        lw_scalar = float(
-            0.25
-            + 0.55 * np.clip((np.nanmedian(logc) - 6.0) / 5.0, 0.0, 1.0)
-        )
-        surveys.plot(
-            ax=ax,
-            column="year",
-            cmap=year_cmap,
-            norm=year_norm,
-            alpha=0.52,
-            edgecolor="#1a3d1a",
-            linewidth=lw_scalar,
-            missing_kwds={
-                "color": "#3a3a48",
-                "edgecolor": "#2d4a2d",
-                "linewidth": 0.35,
-                "alpha": 0.45,
-            },
-            legend=False,
-        )
-
-    _draw_graticule_3857(ax, ll.west, ll.south, ll.east, ll.north, zoom)
-
-    if len(surveys) > 0 and zoom >= 4:
-        max_lbl = 6 if zoom >= 6 else 4
-        largest = surveys.nlargest(max_lbl, "_area")
-        for _, row in largest.iterrows():
-            pt = row.geometry.representative_point()
-            yv = row["year"]
-            if np.isfinite(yv):
-                label = str(int(yv))
-            else:
-                label = str(row["name"])[:10]
-            ax.annotate(
-                label,
-                (pt.x, pt.y),
-                fontsize=5,
-                color="#c8c8c8",
-                ha="center",
-                va="center",
-                alpha=0.85,
-            )
-
-    ax.axis("off")
-
-    if len(surveys) > 0:
-        fig.subplots_adjust(left=0, right=1, top=1, bottom=0.11, wspace=0, hspace=0)
-        cax = fig.add_axes([0.12, 0.02, 0.76, 0.045])
-        cbar = fig.colorbar(sm, cax=cax, orientation="horizontal")
-        cbar.ax.tick_params(labelsize=4, colors="#a0a0a0", length=2, pad=1)
-        cbar.set_label(
-            "Year in dataset id (approx.)",
-            color="#a0a0a0",
-            fontsize=5,
-            labelpad=2,
-        )
-    else:
-        fig.subplots_adjust(left=0, right=1, top=1, bottom=0, wspace=0, hspace=0)
-
-    tile_filename = get_tile_filename(grid_method, zoom, x, y)
-    canvas.print_figure(tile_filename, dpi=100, pad_inches=0, bbox_inches="tight")
-    print(f"{zoom}/{x}/{y}: Navigation tile saved as {tile_filename}")
-    return tile_filename
 
 
 def tile_to_aoi(zoom, x, y):

--- a/lidar_dsm_tile_server.py
+++ b/lidar_dsm_tile_server.py
@@ -71,6 +71,7 @@ import json
 import math
 import os
 import pickle
+import re
 
 import geopandas as gpd
 import mercantile
@@ -80,6 +81,9 @@ import pyproj
 import requests
 import rioxarray as rio
 from flask import Flask, send_file
+from matplotlib import cm as mpl_cm
+from matplotlib import colors as mpl_colors
+from matplotlib.cm import ScalarMappable
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 from rasterio.enums import Resampling
@@ -614,6 +618,23 @@ _NE_110M_URL = (
     "geojson/ne_110m_admin_0_countries.geojson"
 )
 _WORLD_OUTLINE_3857 = None
+_SURVEYS_META_GDF_3857 = None
+
+_YEAR_IN_NAME = re.compile(r"\b((?:19|20)\d{2})\b")
+
+
+def _parse_acquisition_year_from_survey_name(name):
+    """
+    resources.geojson has no explicit collection-year field; USGS dataset ids
+    usually embed a four-digit year (e.g. AK_BrooksCamp_2012). Last match wins
+    when several years appear (e.g. project phases).
+    """
+    if name is None:
+        return None
+    matches = _YEAR_IN_NAME.findall(str(name))
+    if not matches:
+        return None
+    return int(matches[-1])
 
 
 def tile_max_side_meters_3857(x, y, zoom):
@@ -658,6 +679,47 @@ def world_countries_3857():
     return _WORLD_OUTLINE_3857
 
 
+def surveys_metadata_gdf_3857():
+    """
+    3DEP public EPT footprints (hobuinc/usgs-lidar resources.geojson) in Web Mercator.
+
+    Only name / count / geometry are authoritative; acquisition year is inferred
+    from the dataset id string when present (same idea as USGS 'by collection
+    year' overview maps, but approximate).
+    """
+    global _SURVEYS_META_GDF_3857
+    if _SURVEYS_META_GDF_3857 is not None:
+        return _SURVEYS_META_GDF_3857
+    n = len(geometries_EPSG3857)
+    years = []
+    for i in range(n):
+        years.append(_parse_acquisition_year_from_survey_name(names.iloc[i]))
+    year_col = np.array(
+        [float(y) if y is not None else np.nan for y in years], dtype=np.float64
+    )
+    counts = np.asarray(num_points, dtype=np.float64)
+    counts = np.where(np.isfinite(counts) & (counts > 0), counts, np.nan)
+    _SURVEYS_META_GDF_3857 = gpd.GeoDataFrame(
+        {
+            "name": names.values,
+            "count": counts,
+            "year": year_col,
+            "geometry": geometries_EPSG3857.values,
+        },
+        crs="EPSG:3857",
+    )
+    return _SURVEYS_META_GDF_3857
+
+
+def _surveys_intersecting_tile_3857(tile_poly):
+    gdf = surveys_metadata_gdf_3857()
+    cand = list(gdf.sindex.intersection(tile_poly.bounds))
+    if not cand:
+        return gdf.iloc[[]].copy()
+    sub = gdf.iloc[cand]
+    return sub[sub.intersects(tile_poly)].copy()
+
+
 def _graticule_step_deg(zoom):
     if zoom <= 1:
         return 45
@@ -689,10 +751,18 @@ def _draw_graticule_3857(ax, west, south, east, north, zoom):
 
 def render_navigation_tile_png(zoom, x, y, grid_method, tile_size=TILE_PNG_PX):
     """
-    Low-zoom bearings layer: coastlines + graticule in Web Mercator (no LiDAR).
+    Low-zoom bearings layer (no LiDAR): Natural Earth coastlines, graticule, and
+    USGS public EPT survey footprints from resources.geojson.
+
+    Survey polygons use fill color by acquisition year parsed from the dataset id
+    (resources have no separate year field). Edge weight scales slightly with
+    log10(point count) so larger acquisitions read heavier—similar in spirit to
+    overview maps that combine coverage with vintage / quality cues.
     """
     bbox_m = mercantile.xy_bounds(x, y, zoom)
     ll = mercantile.bounds(x, y, zoom)
+    tile_poly = box(bbox_m.left, bbox_m.bottom, bbox_m.right, bbox_m.top)
+
     fig = Figure(figsize=(tile_size / 100, tile_size / 100), dpi=100)
     canvas = FigureCanvasAgg(fig)
     ax = fig.add_subplot(111)
@@ -703,10 +773,82 @@ def render_navigation_tile_png(zoom, x, y, grid_method, tile_size=TILE_PNG_PX):
 
     world = world_countries_3857()
     world.boundary.plot(ax=ax, color="#4a5f78", linewidth=0.65, antialiased=True)
+
+    surveys = _surveys_intersecting_tile_3857(tile_poly)
+    year_norm = mpl_colors.Normalize(vmin=1998.0, vmax=2026.0)
+    try:
+        year_cmap = mpl_cm.colormaps["YlGnBu"]
+    except AttributeError:
+        year_cmap = mpl_cm.get_cmap("YlGnBu")
+    sm = ScalarMappable(norm=year_norm, cmap=year_cmap)
+    sm.set_array([])
+
+    if len(surveys) > 0:
+        surveys = surveys.assign(_area=surveys.geometry.area).sort_values(
+            "_area", ascending=True
+        )
+        logc = np.log10(
+            np.maximum(surveys["count"].to_numpy(dtype=np.float64), 1.0)
+        )
+        lw_scalar = float(
+            0.25
+            + 0.55 * np.clip((np.nanmedian(logc) - 6.0) / 5.0, 0.0, 1.0)
+        )
+        surveys.plot(
+            ax=ax,
+            column="year",
+            cmap=year_cmap,
+            norm=year_norm,
+            alpha=0.52,
+            edgecolor="#1a3d1a",
+            linewidth=lw_scalar,
+            missing_kwds={
+                "color": "#3a3a48",
+                "edgecolor": "#2d4a2d",
+                "linewidth": 0.35,
+                "alpha": 0.45,
+            },
+            legend=False,
+        )
+
     _draw_graticule_3857(ax, ll.west, ll.south, ll.east, ll.north, zoom)
 
+    if len(surveys) > 0 and zoom >= 4:
+        max_lbl = 6 if zoom >= 6 else 4
+        largest = surveys.nlargest(max_lbl, "_area")
+        for _, row in largest.iterrows():
+            pt = row.geometry.representative_point()
+            yv = row["year"]
+            if np.isfinite(yv):
+                label = str(int(yv))
+            else:
+                label = str(row["name"])[:10]
+            ax.annotate(
+                label,
+                (pt.x, pt.y),
+                fontsize=5,
+                color="#c8c8c8",
+                ha="center",
+                va="center",
+                alpha=0.85,
+            )
+
     ax.axis("off")
-    fig.subplots_adjust(left=0, right=1, top=1, bottom=0, wspace=0, hspace=0)
+
+    if len(surveys) > 0:
+        fig.subplots_adjust(left=0, right=1, top=1, bottom=0.11, wspace=0, hspace=0)
+        cax = fig.add_axes([0.12, 0.02, 0.76, 0.045])
+        cbar = fig.colorbar(sm, cax=cax, orientation="horizontal")
+        cbar.ax.tick_params(labelsize=4, colors="#a0a0a0", length=2, pad=1)
+        cbar.set_label(
+            "Year in dataset id (approx.)",
+            color="#a0a0a0",
+            fontsize=5,
+            labelpad=2,
+        )
+    else:
+        fig.subplots_adjust(left=0, right=1, top=1, bottom=0, wspace=0, hspace=0)
+
     tile_filename = get_tile_filename(grid_method, zoom, x, y)
     canvas.print_figure(tile_filename, dpi=100, pad_inches=0, bbox_inches="tight")
     print(f"{zoom}/{x}/{y}: Navigation tile saved as {tile_filename}")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Navigation tiles (zoom 0–7)

- **Only** 3DEP EPT survey footprints from `resources.geojson` (same polygons as the LiDAR path). **Transparent PNG** except for those polygons so the map client’s own basemap (states, coast, etc.) shows through.
- **No** Natural Earth, **no** graticule, **no** colorbar, **no** legends, **no** text labels, **no** choropleth or other in-tile metadata—plain map tiles.

### LiDAR zooms 8–13

Crossfade from smoothed DSM toward high-pass; zoom 14+ high-pass only (unchanged).

### Other

EPT `resolution` / DSM cell size tied to tile span (#8); Gaussian sigma scales with GSD (#36).

## Notes

Ensure the map stack draws the LiDAR layer **above** the geography basemap so semi-transparent green footprints read clearly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83a0832b-d434-465f-95d7-230117c3856f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83a0832b-d434-465f-95d7-230117c3856f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

